### PR TITLE
fix: update Android and iOS scripts to run on device

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -19,4 +19,16 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+// Resolve the library directly from source for live development
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === '@edwardloopez/react-native-coachmark') {
+    return {
+      filePath: path.resolve(monorepoRoot, 'src/index.tsx'),
+      type: 'sourceFile',
+    };
+  }
+  // Use default resolver for everything else
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = config;

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
+    "android": "expo run:android --device",
+    "ios": "expo run:ios --device",
     "web": "expo start --web"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request introduces improvements to the development workflow for the example app, focusing on live development and device targeting. The most important changes are grouped below.

Development workflow enhancements:

* Updated the Metro bundler configuration in `example/metro.config.js` to resolve the `@edwardloopez/react-native-coachmark` library directly from its source (`src/index.tsx`) for live development, enabling immediate reflection of code changes without rebuilding the library.

Script improvements for device targeting:

* Modified the `android` and `ios` scripts in `example/package.json` to include the `--device` flag, ensuring that Expo runs on a connected device rather than the default simulator/emulator.