### PR TITLE
fix: remove total downloads badge from README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="https://bundlephobia.com/package/@edwardloopez/react-native-coachmark"><img src="https://img.shields.io/bundlephobia/minzip/@edwardloopez/react-native-coachmark" alt="Bundle Size" /></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
   <a href="https://www.npmjs.com/package/@edwardloopez/react-native-coachmark"><img src="https://img.shields.io/npm/dm/@edwardloopez/react-native-coachmark.svg" alt="Downloads (monthly)" /></a>
-  <a href="https://www.npmjs.com/package/@edwardloopez/react-native-coachmark"><img src="https://img.shields.io/npm/dt/@edwardloopez/react-native-coachmark.svg" alt="Downloads (total)" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by removing the badge that displayed the total number of downloads from npm.