### PR TITLE
fix: expose renderTooltip option in createTour DSL

### DIFF
--- a/.changeset/wacky-singers-glow.md
+++ b/.changeset/wacky-singers-glow.md
@@ -1,0 +1,5 @@
+---
+'@edwardloopez/react-native-coachmark': patch
+---
+
+fix: expose `renderTooltip` option in `createTour` DSL

--- a/src/__tests__/createTour.test.ts
+++ b/src/__tests__/createTour.test.ts
@@ -79,4 +79,13 @@ describe('createTour', () => {
     expect(tour.key).toBe('test-tour');
     expect(tour.steps).toEqual(mockSteps);
   });
+
+  it('should create a tour with renderTooltip option', () => {
+    const mockRenderer = jest.fn();
+    const tour = createTour('test-tour', mockSteps, {
+      renderTooltip: mockRenderer,
+    });
+
+    expect(tour.renderTooltip).toBe(mockRenderer);
+  });
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,7 +45,6 @@ export type TourStep = {
   onBeforeEnter?: () => Promise<boolean | void>;
   onEnter?: () => void;
   onExit?: () => void;
-  // Custom tooltip renderer
   renderTooltip?: TooltipRenderer;
 };
 

--- a/src/dsl/createTour.ts
+++ b/src/dsl/createTour.ts
@@ -1,4 +1,4 @@
-import type { Tour, TourStep } from '../core/types';
+import type { Tour, TourStep, TooltipRenderer } from '../core/types';
 
 /**
  * Creates a tour configuration object with the specified steps and options.
@@ -8,6 +8,7 @@ import type { Tour, TourStep } from '../core/types';
  * @param opts - Optional configuration options for the tour
  * @param opts.showOnce - If true, the tour will only be shown once to the user
  * @param opts.delay - Delay in milliseconds before the tour starts
+ * @param opts.renderTooltip - Global custom tooltip renderer for all steps
  * @returns A Tour object containing the key, steps, and optional configuration
  *
  * @example
@@ -22,7 +23,13 @@ import type { Tour, TourStep } from '../core/types';
 export function createTour(
   key: string,
   steps: TourStep[],
-  opts?: { showOnce?: boolean; delay?: number }
+  opts?: { showOnce?: boolean; delay?: number; renderTooltip?: TooltipRenderer }
 ): Tour {
-  return { key, steps, showOnce: opts?.showOnce, delay: opts?.delay };
+  return {
+    key,
+    steps,
+    showOnce: opts?.showOnce,
+    delay: opts?.delay,
+    renderTooltip: opts?.renderTooltip,
+  };
 }


### PR DESCRIPTION
The Tour type already defined renderTooltip?: TooltipRenderer but createTour() did not accept or propagate it, making the global custom tooltip renderer inaccessible via the DSL.

- Add renderTooltip to createTour opts parameter
- Import TooltipRenderer type in createTour.ts
- Add test coverage for the new option

Closes #25