### PR TITLE
fix(android): prevent crashes when displaying the mask on some Android devices

### DIFF
--- a/.changeset/full-bikes-taste.md
+++ b/.changeset/full-bikes-taste.md
@@ -1,0 +1,5 @@
+---
+'@edwardloopez/react-native-coachmark': patch
+---
+
+fix(android): avoid invalid SVG path when circle hole has negative dimensions

--- a/src/ui/Mask.tsx
+++ b/src/ui/Mask.tsx
@@ -91,7 +91,7 @@ export const AnimatedMask: React.FC<{
         if (h.shape === 'circle') {
           const cx = rect.x + rect.width / 2;
           const cy = rect.y + rect.height / 2;
-          const r = Math.max(rect.width, rect.height) / 2;
+          const r = Math.abs(Math.max(rect.width, rect.height) / 2);
           return `M ${cx} ${cy} m -${r},0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${r * 2},0`;
         }
 

--- a/src/ui/shapes.ts
+++ b/src/ui/shapes.ts
@@ -42,7 +42,7 @@ export function inset(rect: Rect, pad: number): Rect {
 export function pathForCircle(rect: Rect): string {
   const cx = rect.x + rect.width / 2;
   const cy = rect.y + rect.height / 2;
-  const r = Math.max(rect.width, rect.height) / 2;
+  const r = Math.abs(Math.max(rect.width, rect.height) / 2);
   return `M ${cx} ${cy} m -${r}, 0 a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${r * 2},0`;
 }
 


### PR DESCRIPTION
The radius of the negative circle generated an invalid SVG path (--number) on Android.

Fixes #28