### PR TITLE
feat: add nextOnBackdropPress option to tour configuration

### DIFF
--- a/.changeset/new-results-shake.md
+++ b/.changeset/new-results-shake.md
@@ -1,0 +1,5 @@
+---
+'@edwardloopez/react-native-coachmark': patch
+---
+
+Add nextOnBackdropPress option to Tour and TourStep to prevent backdrop taps from advancing the tour (defaults to true)

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ const tour = createTour(
 | `onEnter` | function | - | Callback when step becomes active |
 | `onExit` | function | - | Callback when leaving step |
 | `renderTooltip` | React.ComponentType | - | Custom tooltip component for this step |
+| `nextOnBackdropPress` | boolean | `true` | If `false`, tapping the backdrop won't advance the tour |
 
 **Tour Options:**
 
@@ -241,6 +242,7 @@ const tour = createTour(
 | `showOnce` | boolean | false | Show tour only once (requires storage) |
 | `delay` | number | 0 | Delay before tour starts (milliseconds) |
 | `renderTooltip` | React.ComponentType | - | Global custom tooltip renderer for all steps |
+| `nextOnBackdropPress` | boolean | `true` | If `false`, tapping the backdrop won't advance the tour |
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -416,7 +416,9 @@ function MainApp() {
       description: 'Press ? to see all keyboard shortcuts',
       placement: 'bottom',
     },
-  ]);
+  ], {
+    nextOnBackdropPress: false, // Require explicit Next button
+  });
 
   useEffect(() => {
     // Auto-start appropriate tour based on user type

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -84,6 +84,7 @@ export function HomeScreen({ navigation }: HomeScreenProps) {
             shape: 'rect',
             radius: 16,
             placement: 'top',
+            nextOnBackdropPress: false,
           },
         ],
         { showOnce: true }

--- a/src/__tests__/createTour.test.ts
+++ b/src/__tests__/createTour.test.ts
@@ -88,4 +88,12 @@ describe('createTour', () => {
 
     expect(tour.renderTooltip).toBe(mockRenderer);
   });
+
+  it('should create a tour with nextOnBackdropPress option', () => {
+    const tour = createTour('test-tour', mockSteps, {
+      nextOnBackdropPress: false,
+    });
+
+    expect(tour.nextOnBackdropPress).toBe(false);
+  });
 });

--- a/src/__tests__/resolveNextOnBackdropPress.test.ts
+++ b/src/__tests__/resolveNextOnBackdropPress.test.ts
@@ -1,0 +1,37 @@
+import type { Tour, TourStep } from '../core/types';
+import { resolveNextOnBackdropPress } from '../utils/resolveNextOnBackdropPress';
+
+describe('resolveNextOnBackdropPress', () => {
+  const step: TourStep = { id: 'step1' };
+  const tour: Tour = { key: 'tour', steps: [step] };
+
+  it('should default to true when no config is provided', () => {
+    expect(resolveNextOnBackdropPress()).toBe(true);
+    expect(resolveNextOnBackdropPress(step)).toBe(true);
+    expect(resolveNextOnBackdropPress(step, tour)).toBe(true);
+  });
+
+  it('should use tour-level false', () => {
+    expect(
+      resolveNextOnBackdropPress(step, { ...tour, nextOnBackdropPress: false })
+    ).toBe(false);
+  });
+
+  it('should let step override tour false with true', () => {
+    expect(
+      resolveNextOnBackdropPress(
+        { ...step, nextOnBackdropPress: true },
+        { ...tour, nextOnBackdropPress: false }
+      )
+    ).toBe(true);
+  });
+
+  it('should let step override tour true with false', () => {
+    expect(
+      resolveNextOnBackdropPress(
+        { ...step, nextOnBackdropPress: false },
+        { ...tour, nextOnBackdropPress: true }
+      )
+    ).toBe(false);
+  });
+});

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -46,6 +46,7 @@ export type TourStep = {
   onEnter?: () => void;
   onExit?: () => void;
   renderTooltip?: TooltipRenderer;
+  nextOnBackdropPress?: boolean;
 };
 
 export type Tour = {
@@ -54,6 +55,7 @@ export type Tour = {
   showOnce?: boolean;
   delay?: number;
   renderTooltip?: TooltipRenderer;
+  nextOnBackdropPress?: boolean;
 };
 
 export type CoachmarkTheme = {

--- a/src/dsl/createTour.ts
+++ b/src/dsl/createTour.ts
@@ -9,6 +9,7 @@ import type { Tour, TourStep, TooltipRenderer } from '../core/types';
  * @param opts.showOnce - If true, the tour will only be shown once to the user
  * @param opts.delay - Delay in milliseconds before the tour starts
  * @param opts.renderTooltip - Global custom tooltip renderer for all steps
+ * @param opts.nextOnBackdropPress - If false, tapping the backdrop won't call next
  * @returns A Tour object containing the key, steps, and optional configuration
  *
  * @example
@@ -23,7 +24,12 @@ import type { Tour, TourStep, TooltipRenderer } from '../core/types';
 export function createTour(
   key: string,
   steps: TourStep[],
-  opts?: { showOnce?: boolean; delay?: number; renderTooltip?: TooltipRenderer }
+  opts?: {
+    showOnce?: boolean;
+    delay?: number;
+    renderTooltip?: TooltipRenderer;
+    nextOnBackdropPress?: boolean;
+  }
 ): Tour {
   return {
     key,
@@ -31,5 +37,6 @@ export function createTour(
     showOnce: opts?.showOnce,
     delay: opts?.delay,
     renderTooltip: opts?.renderTooltip,
+    nextOnBackdropPress: opts?.nextOnBackdropPress,
   };
 }

--- a/src/ui/CoachmarkOverlay.tsx
+++ b/src/ui/CoachmarkOverlay.tsx
@@ -21,6 +21,7 @@ import { useOrientationChange } from '../hooks/useOrientationChange';
 import { useTooltipPosition } from '../hooks/useTooltipPosition';
 import { useTourMeasurement } from '../hooks/useTourMeasurement';
 import { isReduceMotionEnabled } from '../utils/accessibility';
+import { resolveNextOnBackdropPress } from '../utils/resolveNextOnBackdropPress';
 
 import { CoachmarkErrorBoundary } from './CoachmarkErrorBoundary';
 import { AnimatedMask } from './Mask';
@@ -146,6 +147,11 @@ export const CoachmarkOverlay: React.FC = () => {
   const customRenderer =
     activeStep.renderTooltip || state.activeTour?.renderTooltip;
 
+  const nextOnBackdropPress = resolveNextOnBackdropPress(
+    activeStep,
+    state.activeTour
+  );
+
   return (
     <Modal
       transparent
@@ -171,7 +177,10 @@ export const CoachmarkOverlay: React.FC = () => {
           backdropOpacity={theme.backdropOpacity}
         />
 
-        <Pressable style={StyleSheet.absoluteFill} onPress={next} />
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={nextOnBackdropPress ? next : undefined}
+        />
 
         <Animated.View
           style={[

--- a/src/utils/resolveNextOnBackdropPress.ts
+++ b/src/utils/resolveNextOnBackdropPress.ts
@@ -1,0 +1,8 @@
+import type { Tour, TourStep } from '../core/types';
+
+export function resolveNextOnBackdropPress(
+  step?: TourStep,
+  tour?: Tour | null
+): boolean {
+  return step?.nextOnBackdropPress ?? tour?.nextOnBackdropPress ?? true;
+}


### PR DESCRIPTION
Add nextOnBackdropPress to Tour and TourStep to control backdrop tap behavior. Update docs, examples, and tests.

Ref #30