### PR TITLE
chore: enable npm publish provenance in package.json for pnpm 11 compatibility

### DIFF
--- a/.changeset/easy-pumas-stop.md
+++ b/.changeset/easy-pumas-stop.md
@@ -1,0 +1,5 @@
+---
+'@edwardloopez/react-native-coachmark': patch
+---
+
+Enable npm publish provenance via publishConfig for pnpm 11 compatibility

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@
 # Source: https://github.com/lirantal/npm-security-best-practices
 version: 2
 updates:
+  # Library root: devDependencies only (grouped weekly PR)
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -16,6 +17,26 @@ updates:
         dependency-type: development
         patterns:
           - '*'
+
+  # Example app: Expo/RN packages are pinned to the SDK — update with `npx expo install`
+  - package-ecosystem: npm
+    directory: /example
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: 'expo'
+      - dependency-name: 'expo-*'
+      - dependency-name: '@expo/*'
+      - dependency-name: 'react'
+      - dependency-name: 'react-dom'
+      - dependency-name: 'react-native'
+      - dependency-name: 'react-native-*'
+      - dependency-name: 'react-native-web'
+      - dependency-name: '@react-native/*'
+      - dependency-name: '@react-navigation/*'
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "homepage": "https://github.com/edwardloopez/react-native-coachmark#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",


### PR DESCRIPTION
- Remove NPM_CONFIG_PROVENANCE from the release workflow.
- Configure Dependabot with weekly devDependency groups at root and monthly
- Updates for the example app, ignoring Expo/RN SDK-pinned packages.